### PR TITLE
Implement graphlite DAG executor

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,50 @@
+"""Example pipeline demonstrating graphlite usage."""
+from __future__ import annotations
+
+from statistics import mean as stats_mean
+
+from graphlite import Executor, conditional, fanout, task
+
+
+@task
+def prepare(n: int) -> list[int]:
+    return list(range(1, n + 1))
+
+
+@task
+def square(value: int) -> int:
+    return value * value
+
+
+@task
+def mean(values: list[int]) -> float:
+    return stats_mean(values)
+
+
+@task
+def choose_total(values: list[int]) -> float:
+    total = sum(values)
+    return float(total)
+
+
+@task
+def take_mean(n: int) -> bool:
+    return n % 2 == 0
+
+
+@task
+def pipeline(n: int) -> float:
+    numbers = prepare(n)
+    squares = fanout(square, numbers)
+    return conditional(take_mean(n), mean(squares), choose_total(numbers))
+
+
+def main() -> None:
+    expr = pipeline(10)
+    with Executor() as executor:
+        result = executor.evaluate(expr)
+    print(f"mean of squares 1..10 = {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/graphlite/__init__.py
+++ b/graphlite/__init__.py
@@ -1,0 +1,8 @@
+"""graphlite - a tiny task graph and graph reduction framework."""
+from __future__ import annotations
+
+from .combinators import conditional, fanout
+from .executor import Executor
+from .task import Task, task
+
+__all__ = ["Task", "task", "Executor", "fanout", "conditional"]

--- a/graphlite/combinators.py
+++ b/graphlite/combinators.py
@@ -1,0 +1,23 @@
+"""High level helpers for building composite expressions."""
+from __future__ import annotations
+
+from typing import Iterable, TypeVar
+
+from .expr import ConditionalExpr, Expr, MapExpr
+from .task import Task
+from .utils import to_expr
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def fanout(task: Task[..., R], items: Iterable[T] | Expr) -> Expr:
+    """Map ``task`` across ``items`` with parallel evaluation."""
+
+    return MapExpr(task, to_expr(items))
+
+
+def conditional(condition: bool | Expr, if_true: Expr, if_false: Expr) -> Expr:
+    """Select between two expressions based on ``condition`` lazily."""
+
+    return ConditionalExpr(to_expr(condition), to_expr(if_true), to_expr(if_false))

--- a/graphlite/context.py
+++ b/graphlite/context.py
@@ -1,0 +1,36 @@
+"""Thread-local evaluation context used during graph reduction."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from threading import local
+from typing import Optional
+
+
+class _ContextState(local):
+    def __init__(self) -> None:
+        super().__init__()
+        self.executor: Optional["Executor"] = None
+
+
+_state = _ContextState()
+
+
+@contextmanager
+def use_executor(executor: "Executor"):
+    prev = _state.executor
+    _state.executor = executor
+    try:
+        yield
+    finally:
+        _state.executor = prev
+
+
+def current_executor() -> Optional["Executor"]:
+    return _state.executor
+
+
+# Late import for type checking only.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .executor import Executor

--- a/graphlite/executor.py
+++ b/graphlite/executor.py
@@ -1,0 +1,74 @@
+"""Graph reduction executor evaluating expressions produced by tasks."""
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from typing import Any, Dict, Iterable
+from .expr import CallExpr, ConditionalExpr, Expr, MapExpr, ValueExpr
+
+
+class Executor:
+    """Evaluates expressions by recursively reducing the dependency graph.
+
+    Graph reduction evaluates the DAG from the leaves upward: every dependency of an
+    expression is resolved before the expression itself is computed. Because expressions
+    capture both tasks and concrete values, the executor can transparently traverse the
+    graph, execute tasks, and reuse cached results as it goes.
+    """
+
+    def __init__(self, max_workers: int | None = None) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._cache: Dict[int, Any] = {}
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=True)
+
+    def evaluate(self, expr: Expr) -> Any:
+        if isinstance(expr, ValueExpr):
+            return expr.value
+        if expr.id in self._cache:
+            return self._cache[expr.id]
+        result = self._evaluate(expr)
+        self._cache[expr.id] = result
+        return result
+
+    def _evaluate(self, expr: Expr) -> Any:
+        if isinstance(expr, ValueExpr):
+            return expr.value
+        if isinstance(expr, CallExpr):
+            args = tuple(self.evaluate(arg) for arg in expr.args)
+            kwargs = {name: self.evaluate(val) for name, val in expr.kwargs.items()}
+            result = expr.task.execute(self, args, kwargs)
+            if isinstance(result, Expr):
+                return self.evaluate(result)
+            return result
+        if isinstance(expr, MapExpr):
+            items = list(self.evaluate(expr.items))
+            futures: list[Future[Any]] = []
+            for item in items:
+                call_expr = CallExpr(expr.task, (ValueExpr(item),), {})
+                futures.append(self._executor.submit(self.evaluate, call_expr))
+            wait(futures)
+            return [future.result() for future in futures]
+        if isinstance(expr, ConditionalExpr):
+            condition = bool(self.evaluate(expr.condition))
+            branch = expr.if_true if condition else expr.if_false
+            return self.evaluate(branch)
+        raise TypeError(f"Unknown expression type: {type(expr)!r}")
+
+    def map(self, task: "Task[Any, Any]", items: Iterable[Any]) -> list[Any]:
+        futures = [self._executor.submit(task.execute, self, (item,), {}) for item in items]
+        wait(futures)
+        return [fut.result() for fut in futures]
+
+    def __enter__(self) -> "Executor":  # pragma: no cover - convenience
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - convenience
+        self.close()
+
+
+# Late import for type checking only.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .task import Task

--- a/graphlite/expr.py
+++ b/graphlite/expr.py
@@ -1,0 +1,80 @@
+"""Core expression data structures used for graph construction and reduction."""
+from __future__ import annotations
+
+from itertools import count
+from typing import Any, Iterable, Mapping
+
+
+_expr_ids = count()
+
+
+def _next_id() -> int:
+    return next(_expr_ids)
+
+
+class Expr:
+    """Base class for all expressions in the evaluation graph."""
+
+    id: int
+
+    def __init__(self) -> None:
+        self.id = _next_id()
+
+    def iter_children(self) -> Iterable["Expr"]:
+        return ()
+
+
+class ValueExpr(Expr):
+    """Expression representing a concrete Python value."""
+
+    def __init__(self, value: Any) -> None:
+        super().__init__()
+        self.value = value
+
+
+class CallExpr(Expr):
+    """Expression representing invocation of a task with arguments."""
+
+    def __init__(self, task: "Task[Any, Any]", args: tuple[Expr, ...], kwargs: Mapping[str, Expr]) -> None:
+        super().__init__()
+        self.task = task
+        self.args = args
+        self.kwargs = dict(kwargs)
+
+    def iter_children(self) -> Iterable[Expr]:
+        yield from self.args
+        yield from self.kwargs.values()
+
+
+class MapExpr(Expr):
+    """Expression that maps a task over an iterable of values in parallel."""
+
+    def __init__(self, task: "Task[Any, Any]", items: Expr) -> None:
+        super().__init__()
+        self.task = task
+        self.items = items
+
+    def iter_children(self) -> Iterable[Expr]:
+        yield self.items
+
+
+class ConditionalExpr(Expr):
+    """Expression encoding a branch based on the result of a condition expression."""
+
+    def __init__(self, condition: Expr, if_true: Expr, if_false: Expr) -> None:
+        super().__init__()
+        self.condition = condition
+        self.if_true = if_true
+        self.if_false = if_false
+
+    def iter_children(self) -> Iterable[Expr]:
+        yield self.condition
+        yield self.if_true
+        yield self.if_false
+
+
+# Late import for type checking only.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .task import Task

--- a/graphlite/task.py
+++ b/graphlite/task.py
@@ -1,0 +1,63 @@
+"""Task decorator and runtime wrapper implementing the typing illusion."""
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Generic, Mapping, ParamSpec, TypeVar, cast, overload
+
+from . import context
+from .expr import CallExpr
+from .utils import to_expr
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+class Task(Generic[P, R]):
+    """Wrap a callable so the type checker sees a normal function while runtime is lazy.
+
+    The class masquerades as the original callable by reusing its ``__call__`` signature
+    (thanks to :class:`typing.ParamSpec`). Static type checkers therefore treat instances
+    exactly like the wrapped function. At runtime the wrapper either constructs a lazy
+    expression (when no executor is active) or immediately evaluates the expression via
+    the current evaluation context. This mirrors the "typing illusion" popularized by
+    the redun project.
+    """
+
+    def __init__(self, func: Callable[P, R], name: str | None = None) -> None:
+        self.func = func
+        self.name = name or func.__name__
+        wraps(func)(self)
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        executor = context.current_executor()
+        expr = CallExpr(self, tuple(to_expr(arg) for arg in args), {k: to_expr(v) for k, v in kwargs.items()})
+        if executor is not None:
+            return cast(R, executor.evaluate(expr))
+        return cast(R, expr)
+
+    def __get__(self, obj: Any, objtype: type[Any]) -> Callable[P, R]:  # pragma: no cover - descriptor delegation
+        return cast(Callable[P, R], self.__call__.__get__(obj, objtype))
+
+    def execute(self, executor: "Executor", args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> R:
+        """Execute the underlying function within an evaluation context."""
+
+        with context.use_executor(executor):
+            return self.func(*args, **kwargs)
+
+
+@overload
+def task(func: Callable[P, R]) -> Task[P, R]:
+    ...
+
+
+def task(func: Callable[P, R]) -> Task[P, R]:
+    """Decorator turning a function into a :class:`Task` with lazy semantics."""
+
+    return Task(func)
+
+
+# Late import for type checking only.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .executor import Executor

--- a/graphlite/utils.py
+++ b/graphlite/utils.py
@@ -1,0 +1,14 @@
+"""Helper utilities for working with expressions."""
+from __future__ import annotations
+
+from typing import Any
+
+from .expr import Expr, ValueExpr
+
+
+def to_expr(value: Any) -> Expr:
+    """Convert raw values or expressions into :class:`Expr` instances."""
+
+    if isinstance(value, Expr):
+        return value
+    return ValueExpr(value)

--- a/tests/test_graphlite.py
+++ b/tests/test_graphlite.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from time import sleep
+from typing import Any
+
+import pytest
+
+from graphlite import Executor, conditional, fanout, task
+
+
+@task
+def prepare(n: int) -> list[int]:
+    return list(range(1, n + 1))
+
+
+@task
+def sum_ints(values: list[int]) -> int:
+    return sum(values)
+
+
+@task
+def square(value: int) -> int:
+    sleep(0.01)
+    return value * value
+
+
+@task
+def mean(values: list[int]) -> float:
+    return sum(values) / len(values)
+
+
+@task
+def is_even(n: int) -> bool:
+    return n % 2 == 0
+
+
+@task
+def choose(values: list[int]) -> int:
+    return len(values)
+
+
+def evaluate(expr: Any) -> Any:
+    with Executor() as executor:
+        return executor.evaluate(expr)
+
+
+def test_simple_chain() -> None:
+    result = evaluate(sum_ints(prepare(5)))
+    assert result == 15
+
+
+def test_fanout_mean() -> None:
+    result = evaluate(mean(fanout(square, prepare(10))))
+    assert result == pytest.approx(38.5)
+
+
+def test_conditional() -> None:
+    expr = conditional(is_even(4), sum_ints(prepare(2)), choose(prepare(3)))
+    assert evaluate(expr) == 3
+    expr = conditional(is_even(3), sum_ints(prepare(2)), choose(prepare(3)))
+    assert evaluate(expr) == 3
+
+
+def test_typing_signature_preserved() -> None:
+    from typing import get_type_hints
+
+    hints = get_type_hints(prepare)
+    assert hints["n"] is int
+    assert hints["return"] == list[int]
+
+
+def test_parallel_fanout_runs() -> None:
+    result = evaluate(fanout(square, prepare(5)))
+    assert result == [n * n for n in range(1, 6)]


### PR DESCRIPTION
## Summary
- add expression, task, and executor modules to build and reduce static DAGs
- provide combinators, utilities, and a basic example pipeline showcasing fan-out and conditionals
- add pytest-based acceptance tests covering chaining, branching, typing, and parallel fan-out

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. python examples/basic.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134fd0e30c8327a6718ad7c71d3f7b)