### PR TITLE
chore: add initial Codecov config (and temporarily dial down coverage checks)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,5 @@ status:
       target: 90  # TODO: set to 100 for 1.0 release
   patch:
     default:
-      target: 0  # TODO: set to 100 for 1.0 release
+      target: 80  # TODO: set to 100 for 1.0 release
       threshold: 0


### PR DESCRIPTION
This pull request introduces a configuration file for Codecov to define code coverage requirements for the project. The configuration sets targets for both overall project coverage and patch coverage, with comments indicating plans to increase these targets for the 1.0 release.

Codecov configuration:

* Added a `codecov.yml` file to specify code coverage targets: 90% for the overall project and ~0%~ 80% for patches (with plans to raise both to 100% for the 1.0 release).