### PR TITLE
Refactor/backend lifecycle state

### DIFF
--- a/src/daglite/backends/base.py
+++ b/src/daglite/backends/base.py
@@ -65,8 +65,8 @@ class Backend(abc.ABC):
         self.dataset_processor = dataset_processor
         self.event_reporter = self._get_event_reporter()
         self.dataset_reporter = self._get_dataset_reporter()
-        self._started = True
         self._start()
+        self._started = True
 
     def _start(self) -> None:
         """


### PR DESCRIPTION
This pull request improves the lifecycle management of the `Backend` class by introducing a `_started` flag to prevent multiple starts and to simplify resource cleanup. The changes ensure that the backend cannot be started more than once and that stopping the backend is a no-op if it hasn't been started.

Lifecycle management improvements:

* Added a `_started` boolean attribute to the `Backend` class to track whether the backend has been started.
* Updated the `start` method to raise a `RuntimeError` if the backend is already started, and to set `_started` to `True` after initialization.
* Modified the `stop` method to return early if the backend is not started, and to set `_started` to `False` after stopping, instead of deleting various attributes.

Fixes #53 